### PR TITLE
Support rubocop 1.x

### DIFF
--- a/code-scanning-rubocop.gemspec
+++ b/code-scanning-rubocop.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "> 0.82.0"
+  spec.add_dependency "rubocop", "~> 1.0"
 end

--- a/lib/code_scanning.rb
+++ b/lib/code_scanning.rb
@@ -6,3 +6,4 @@ module CodeScanning
 end
 
 require_relative "code_scanning/rubocop/sarif_formatter"
+require_relative "code_scanning/rubocop/version"

--- a/lib/code_scanning/rubocop/version.rb
+++ b/lib/code_scanning/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module CodeScanning
   module Rubocop
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
Bump rubocop to ~> 1.0 and change the gem version to 0.5.0.