### PR TITLE
Generate valid SARIF files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,34 @@
 PATH
   remote: .
   specs:
-    code-scanning-rubocop (0.3.0)
-      rubocop (> 0.82.0)
+    code-scanning-rubocop (0.5.0)
+      rubocop (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
+    ast (2.4.2)
     minitest (5.14.0)
-    parallel (1.19.2)
-    parser (2.7.1.5)
+    parallel (1.21.0)
+    parser (3.1.0.0)
       ast (~> 2.4.1)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (1.8.0)
-    rexml (3.2.4)
-    rubocop (0.92.0)
+    regexp_parser (2.2.0)
+    rexml (3.2.5)
+    rubocop (1.24.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.5.0)
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.5.0)
-      parser (>= 2.7.1.5)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -39,4 +39,4 @@ DEPENDENCIES
   rake (~> 12.0)
 
 BUNDLED WITH
-   2.1.4
+   2.3.4

--- a/lib/code_scanning/rubocop/rule.rb
+++ b/lib/code_scanning/rubocop/rule.rb
@@ -110,11 +110,14 @@ module CodeScanning
       end
 
       if help_uri
-        h["helpUri"] = help_uri
-        h["help"] = {
-          "text" => help(:text),
-          "markdown" => help(:markdown),
-        }
+        h.merge!(
+          "queryURI" => help_uri,
+          "helpUri" => help_uri,
+          "help" => {
+            "text" => help(:text),
+            "markdown" => help(:markdown)
+          }
+        )
       end
 
       h

--- a/lib/code_scanning/rubocop/rule.rb
+++ b/lib/code_scanning/rubocop/rule.rb
@@ -45,8 +45,8 @@ module CodeScanning
       return @cop.documentation_url if @cop.documentation_url
       return nil unless department_uri
 
-      full_name = "#{badge.department.to_s.downcase}#{badge.cop_name.downcase}"
-      "#{department_uri}##{full_name}"
+      anchor = "#{badge.department}#{badge.cop_name}".downcase.tr("/", "")
+      "#{department_uri}##{anchor}"
     end
 
     def department_uri

--- a/lib/code_scanning/rubocop/rule.rb
+++ b/lib/code_scanning/rubocop/rule.rb
@@ -66,7 +66,7 @@ module CodeScanning
 
       h = {
         "id" => @cop_name,
-        "name" => @cop_name,
+        "name" => @cop_name.tr("/", "").gsub("RSpec", "Rspec"),
         "defaultConfiguration" => {
           "level" => sarif_severity
         },

--- a/lib/code_scanning/rubocop/rule.rb
+++ b/lib/code_scanning/rubocop/rule.rb
@@ -8,19 +8,19 @@ module CodeScanning
       @cop_name = cop_name
       @severity = severity.to_s
       @cop = RuboCop::Cop::Cop.registry.find_by_cop_name(cop_name)
-      @help = StringIO.new
     end
 
     def id
       @cop_name
     end
 
-    def append_help(line)
-      @help.print(line)
-    end
-
-    def help_empty?
-      @help.size.zero?
+    def help(format)
+      case format
+      when :text
+        "More info: #{help_uri}"
+      when :markdown
+        "[More info](#{help_uri})"
+      end
     end
 
     def ==(other)
@@ -41,12 +41,36 @@ module CodeScanning
       "none"
     end
 
-    # The URL for the docs are in this format:
-    # https://docs.rubocop.org/en/stable/cops_layout/#layoutblockendnewline
-    def query_uri
-      kind = badge.department.to_s.downcase
-      full_name = "#{kind}#{badge.cop_name.downcase}"
-      "https://docs.rubocop.org/en/stable/cops_#{kind}/##{full_name}"
+    def help_uri
+      return @cop.documentation_url if @cop.documentation_url
+      return nil unless department_uri
+
+      full_name = "#{badge.department.to_s.downcase}#{badge.cop_name.downcase}"
+      "#{department_uri}##{full_name}"
+    end
+
+    def department_uri
+      case badge.department
+      when :Performance
+        "https://docs.rubocop.org/rubocop-performance/index.html"
+      when :Packaging
+        "https://docs.rubocop.org/rubocop-packaging/cops_packaging.html"
+      when :Rails
+        "https://docs.rubocop.org/rubocop-rails/cops_rails.html"
+      when :Minitest
+        "https://docs.rubocop.org/rubocop-minitest/cops_minitest.html"
+      when :RSpec
+        "https://docs.rubocop.org/rubocop-rspec/cops_rspec.html"
+      when :"RSpec/Rails"
+        "https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html"
+      when :"RSpec/Capybara"
+        "https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html"
+      when :"RSpec/FactoryBot"
+        "https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html"
+      else
+        STDERR.puts "WARNING: Unknown docs URI for department #{badge.department}"
+        nil
+      end
     end
 
     def to_json(opts = {})
@@ -80,19 +104,19 @@ module CodeScanning
         properties["description"] = desc
       end
 
-      unless help_empty?
-        help = @help.string
-        h["help"] = {
-          "text" => help,
-          "markdown" => help
-        }
-        properties["queryURI"] = query_uri if badge.qualified?
-      end
-
       if badge.qualified?
         kind = badge.department.to_s
         properties["tags"] = [kind.downcase]
       end
+
+      if help_uri
+        h["helpUri"] = help_uri
+        h["help"] = {
+          "text" => help(:text),
+          "markdown" => help(:markdown),
+        }
+      end
+
       h
     end
   end

--- a/lib/code_scanning/rubocop/sarif_formatter.rb
+++ b/lib/code_scanning/rubocop/sarif_formatter.rb
@@ -65,10 +65,7 @@ module CodeScanning
                 }
               }
             }
-          ],
-          "partialFingerprints" => {
-            # This will be computed by the upload action for now
-          }
+          ]
         }
       end
     end

--- a/lib/code_scanning/rubocop/sarif_formatter.rb
+++ b/lib/code_scanning/rubocop/sarif_formatter.rb
@@ -17,7 +17,12 @@ module CodeScanning
       @sarif["runs"] = [
         {
           "tool" => {
-            "driver" => { "name" => "RuboCop", "rules" => @rules }
+            "driver" => {
+              "name" => "RuboCop",
+              "version" => RuboCop::Version.version,
+              "informationUri" => "https://rubocop.org",
+              "rules" => @rules
+            }
           },
           "results" => @results
         }

--- a/lib/code_scanning/rubocop/sarif_formatter.rb
+++ b/lib/code_scanning/rubocop/sarif_formatter.rb
@@ -52,7 +52,6 @@ module CodeScanning
                 "artifactLocation" => {
                   "uri" => relative_path,
                   "uriBaseId" => "%SRCROOT%",
-                  "index" => 0
                 },
                 "region" => {
                   "startLine" => o.line,


### PR DESCRIPTION
According to the [official SARIF validator](https://sarifweb.azurewebsites.net/Validation), rules need to provide a `helpUri` property. This adds help URLs for all the cops in departments hosted at docs.rubocop.org, and tweaks a couple other minor things so that the generated JSON passes the SARIF validator.