### PR TITLE
Refactor SARIF formatter to correctly handle endColumn in CodeScanning module

### DIFF
--- a/lib/code_scanning/rubocop/sarif_formatter.rb
+++ b/lib/code_scanning/rubocop/sarif_formatter.rb
@@ -61,7 +61,7 @@ module CodeScanning
                 "region" => {
                   "startLine" => o.line,
                   "startColumn" => o.real_column,
-                  "endColumn" => o.last_column.zero? ? o.real_column : o.last_column
+                  "endColumn" => o.last_column.zero? ? o.real_column : o.last_column + 1
                 }
               }
             }


### PR DESCRIPTION
Hi 👋 . I just noticed the highlight ranges in the code scanning alerts are one-character off, and this pull request intends to adjust the endColumn 🙇 .

### Behavior (with / without last_column)

**Before Change (e within name is not highlighted)**

<img width="300" alt="image" src="https://github.com/arthurnn/code-scanning-rubocop/assets/1172471/3b030e66-8b0b-4897-b9fb-741ec93c2c9a">

<img width="300" alt="image" src="https://github.com/arthurnn/code-scanning-rubocop/assets/1172471/60d76837-fdfb-42db-8c02-f522fd170418">

**After Change**

<img width="300" alt="image" src="https://github.com/arthurnn/code-scanning-rubocop/assets/1172471/7973b243-4c11-4889-843f-e41b45bb0a17">

<img width="300" alt="image" src="https://github.com/arthurnn/code-scanning-rubocop/assets/1172471/136db962-e1c9-4c6d-b946-8a9b7cf92f31">

### Tests

Checked the behavior using the following workflow.

```yaml
name: "Rubocop"

on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]
jobs:
  rubocop:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
    steps:
    - name: Checkout repository
      uses: actions/checkout@v4
    - name: Set up Ruby
      uses: ruby/setup-ruby@v1
      with:
        ruby-version: 3.1.4
    # - name: Install Code Scanning integration
    #   run: bundle add code-scanning-rubocop --version 0.6.1 --skip-install
    - name: Install Code Scanning integration
      run: bundle add code-scanning-rubocop --github parroty/code-scanning-rubocop --branch fix-range --skip-install
install
    - name: Install dependencies
      run: bundle install
    - name: Rubocop run
      run: |
        bash -c "
          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
          [[ $? -ne 2 ]]
        "
    - name: Upload Sarif output
      uses: github/codeql-action/upload-sarif@v2
      with:
        sarif_file: rubocop.sarif
```

### Changes

This pull request includes a change to the `file_finished` method in the `lib/code_scanning/rubocop/sarif_formatter.rb` file. The change modifies the calculation of the `endColumn` value. If `o.last_column` is zero, `o.real_column` is used as before, but if `o.last_column` is not zero, one is now added to `o.last_column` to calculate the `endColumn` value.